### PR TITLE
fix: errcheck for parsing CLI flags

### DIFF
--- a/cmd/vault-plugin-auth-centrify/main.go
+++ b/cmd/vault-plugin-auth-centrify/main.go
@@ -16,7 +16,10 @@ import (
 func main() {
 	apiClientMeta := &api.PluginAPIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args[1:])
+
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		fatal(err)
+	}
 
 	tlsConfig := apiClientMeta.GetTLSConfig()
 	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
@@ -28,7 +31,11 @@ func main() {
 		TLSProviderFunc: tlsProviderFunc,
 	})
 	if err != nil {
-		log.L().Error("plugin shutting down", "error", err)
-		os.Exit(1)
+		fatal(err)
 	}
+}
+
+func fatal(err error) {
+	log.L().Error("plugin shutting down", "error", err)
+	os.Exit(1)
 }


### PR DESCRIPTION
# Overview

Add missing error check to `main()` for parsing CLI flags.

# Design of Change

Error check was missing.

# Related Issues/Pull Requests

None

# Contributor Checklist

Fixed in various Vault plugin repositories before such as https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/202 and https://github.com/hashicorp/vault/pull/28692